### PR TITLE
Initially set all links to disabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,40 +7,40 @@
     <link rel="shortcut icon" href="favicon.ico" />
     <link rel="stylesheet" href="css/styles.css" type="text/css" />
 
-    <link rel="stylesheet" href="css/base16-ateliercave.css" type="text/css" class="theme ateliercave" />
-    <link rel="stylesheet" href="css/base16-atelierdune.css" type="text/css" class="theme atelierdune" />
-    <link rel="stylesheet" href="css/base16-atelierestuary.css" type="text/css" class="theme atelierestuary" />
-    <link rel="stylesheet" href="css/base16-atelierforest.css" type="text/css" class="theme atelierforest" />
-    <link rel="stylesheet" href="css/base16-atelierheath.css" type="text/css" class="theme atelierheath" />
-    <link rel="stylesheet" href="css/base16-atelierlakeside.css" type="text/css" class="theme atelierlakeside" />
-    <link rel="stylesheet" href="css/base16-atelierplateau.css" type="text/css" class="theme atelierplateau" />
-    <link rel="stylesheet" href="css/base16-ateliersavanna.css" type="text/css" class="theme ateliersavanna" />
-    <link rel="stylesheet" href="css/base16-atelierseaside.css" type="text/css" class="theme atelierseaside" />
-    <link rel="stylesheet" href="css/base16-ateliersulphurpool.css" type="text/css" class="theme ateliersulphurpool" />
+    <link rel="stylesheet" href="css/base16-ateliercave.css" type="text/css" class="theme ateliercave" disabled />
+    <link rel="stylesheet" href="css/base16-atelierdune.css" type="text/css" class="theme atelierdune" disabled />
+    <link rel="stylesheet" href="css/base16-atelierestuary.css" type="text/css" class="theme atelierestuary" disabled />
+    <link rel="stylesheet" href="css/base16-atelierforest.css" type="text/css" class="theme atelierforest" disabled />
+    <link rel="stylesheet" href="css/base16-atelierheath.css" type="text/css" class="theme atelierheath" disabled />
+    <link rel="stylesheet" href="css/base16-atelierlakeside.css" type="text/css" class="theme atelierlakeside" disabled />
+    <link rel="stylesheet" href="css/base16-atelierplateau.css" type="text/css" class="theme atelierplateau" disabled />
+    <link rel="stylesheet" href="css/base16-ateliersavanna.css" type="text/css" class="theme ateliersavanna" disabled />
+    <link rel="stylesheet" href="css/base16-atelierseaside.css" type="text/css" class="theme atelierseaside" disabled />
+    <link rel="stylesheet" href="css/base16-ateliersulphurpool.css" type="text/css" class="theme ateliersulphurpool" disabled />
 
-    <link rel="stylesheet" href="css/base16-3024.css" type="text/css" class="theme 3024" />
-    <link rel="stylesheet" href="css/base16-ashes.css" type="text/css" class="theme ashes" />
-    <link rel="stylesheet" href="css/base16-bespin.css" type="text/css" class="theme bespin" />
-    <link rel="stylesheet" href="css/base16-bright.css" type="text/css" class="theme bright" />
-    <link rel="stylesheet" href="css/base16-chalk.css" type="text/css" class="theme chalk" />
-    <link rel="stylesheet" href="css/base16-default.css" type="text/css" class="theme default" />
-    <link rel="stylesheet" href="css/base16-eighties.css" type="text/css" class="theme eighties" />
-    <link rel="stylesheet" href="css/base16-flat.css" type="text/css" class="theme flat" />
-    <link rel="stylesheet" href="css/base16-grayscale.css" type="text/css" class="theme grayscale" />
-    <link rel="stylesheet" href="css/base16-greenscreen.css" type="text/css" class="theme greenscreen" />
-    <link rel="stylesheet" href="css/base16-isotope.css" type="text/css" class="theme isotope" />
-    <link rel="stylesheet" href="css/base16-londontube.css" type="text/css" class="theme londontube" />
-    <link rel="stylesheet" href="css/base16-marrakesh.css" type="text/css" class="theme marrakesh" />
-    <link rel="stylesheet" href="css/base16-mocha.css" type="text/css" class="theme mocha" />
-    <link rel="stylesheet" href="css/base16-monokai.css" type="text/css" class="theme monokai" />
-    <link rel="stylesheet" href="css/base16-ocean.css" type="text/css" class="theme ocean" />
-    <link rel="stylesheet" href="css/base16-paraiso.css" type="text/css" class="theme paraiso" />
-    <link rel="stylesheet" href="css/base16-pop.css" type="text/css" class="theme pop" />
-    <link rel="stylesheet" href="css/base16-railscasts.css" type="text/css" class="theme railscasts" />
-    <link rel="stylesheet" href="css/base16-shapeshifter.css" type="text/css" class="theme shapeshifter" />
-    <link rel="stylesheet" href="css/base16-solarized.css" type="text/css" class="theme solarized" />
-    <link rel="stylesheet" href="css/base16-tomorrow.css" type="text/css" class="theme tomorrow" />
-    <link rel="stylesheet" href="css/base16-twilight.css" type="text/css" class="theme twilight" />
+    <link rel="stylesheet" href="css/base16-3024.css" type="text/css" class="theme 3024" disabled />
+    <link rel="stylesheet" href="css/base16-ashes.css" type="text/css" class="theme ashes" disabled />
+    <link rel="stylesheet" href="css/base16-bespin.css" type="text/css" class="theme bespin" disabled />
+    <link rel="stylesheet" href="css/base16-bright.css" type="text/css" class="theme bright" disabled />
+    <link rel="stylesheet" href="css/base16-chalk.css" type="text/css" class="theme chalk" disabled />
+    <link rel="stylesheet" href="css/base16-default.css" type="text/css" class="theme default" disabled />
+    <link rel="stylesheet" href="css/base16-eighties.css" type="text/css" class="theme eighties" disabled />
+    <link rel="stylesheet" href="css/base16-flat.css" type="text/css" class="theme flat" disabled />
+    <link rel="stylesheet" href="css/base16-grayscale.css" type="text/css" class="theme grayscale" disabled />
+    <link rel="stylesheet" href="css/base16-greenscreen.css" type="text/css" class="theme greenscreen" disabled />
+    <link rel="stylesheet" href="css/base16-isotope.css" type="text/css" class="theme isotope" disabled />
+    <link rel="stylesheet" href="css/base16-londontube.css" type="text/css" class="theme londontube" disabled />
+    <link rel="stylesheet" href="css/base16-marrakesh.css" type="text/css" class="theme marrakesh" disabled />
+    <link rel="stylesheet" href="css/base16-mocha.css" type="text/css" class="theme mocha" disabled />
+    <link rel="stylesheet" href="css/base16-monokai.css" type="text/css" class="theme monokai" disabled />
+    <link rel="stylesheet" href="css/base16-ocean.css" type="text/css" class="theme ocean" disabled />
+    <link rel="stylesheet" href="css/base16-paraiso.css" type="text/css" class="theme paraiso" disabled />
+    <link rel="stylesheet" href="css/base16-pop.css" type="text/css" class="theme pop" disabled />
+    <link rel="stylesheet" href="css/base16-railscasts.css" type="text/css" class="theme railscasts" disabled />
+    <link rel="stylesheet" href="css/base16-shapeshifter.css" type="text/css" class="theme shapeshifter" disabled />
+    <link rel="stylesheet" href="css/base16-solarized.css" type="text/css" class="theme solarized" disabled />
+    <link rel="stylesheet" href="css/base16-tomorrow.css" type="text/css" class="theme tomorrow" disabled />
+    <link rel="stylesheet" href="css/base16-twilight.css" type="text/css" class="theme twilight" disabled />
   </head>
   <body>
   <a href="https://github.com/chriskempson/base16"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>


### PR DESCRIPTION
Theme changing does not work in Firefox when links start in the enabled state. Changing the disabled status after all links have loaded has no effect, which pegs the theme to whatever the first link is. All this
change does is set themes as disabled by default and viola, theme switching works in Firefox.