### PR TITLE
Fixed javascript dependancy issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
     </div>
   </div>
   <script type="text/javascript" src="js/jquery.min.js" charset="utf-8"></script>
-  <script async type="text/javascript" src="js/jquery.ba-hashchange.min.js" charset="utf-8"></script>
+  <script type="text/javascript" src="js/jquery.ba-hashchange.min.js" charset="utf-8"></script>
   <script async type="text/javascript" src="js/switch.js" charset="utf-8"></script>
   <script async>
 $(function(){


### PR DESCRIPTION
Fixed javascript dependancy issue, by removing async attribute from script tag.

The bug this commit solves can be reproduced by navigating to a  theme, other than default, and hitting refresh. Sometimes an error is thrown in the console, other times it is not.

The `hashchange` function is sometimes called before the hashchange plugin has loaded. Removing the async attribute on the script tag loading the hashchange plugin solves this issue.