### PR TITLE
Update scheme list

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ To add your own scheme, submit a pull request to https://github.com/chriskempson
 * [Tomorrow](https://github.com/chriskempson/base16-tomorrow-scheme) maintained by [chriskempson](https://github.com/chriskempson)
 * [Materia](https://github.com/Defman21/base16-materia) maintained by
 [Defman21](https://github.com/Defman21)
-[Mexico-Light](https://github.com/drzel/base16-mexico-light-scheme)
+* [Mexico-Light](https://github.com/drzel/base16-mexico-light-scheme) maintained by 
+[drzel](https://github.com/drzel)
+* [Unikitty](https://github.com/joshwlewis/unikitty) maintained by 
+[joshwlewis](https://github.com/joshwlewis)
 
 ## Builder Repositories
 **Repository naming scheme: base16-builder-language**


### PR DESCRIPTION
This adds the Unikitty scheme, which is pending addition at chriskempson/base16-schemes-source#7.

This also fixes a formatting inconsistency in the scheme list (Mexico-Light was sharing a bullet point with Materia).