### PR TITLE
Add base16-builder-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ To add your own scheme, submit a pull request to https://github.com/chriskempson
 **Repository naming scheme: base16-builder-language**
 * [Base 16 Builder go](https://github.com/belak/base16-builder-go) maintained by [belak](https://github.com/belak)
 * [Base 16 Builder PHP](https://github.com/chriskempson/base16-builder-php) maintained by [chriskempson](https://github.com/chriskempson)
+* [Base 16 Builder Node.js](https://github.com/richardneililagan/base16-builder-node) maintained by [richardneililagan](https://github.com/richardneililagan)
 
 ## Scheme and Template Author Resources
 The following is a list of useful resources for anyone creating a base16 scheme and or template:


### PR DESCRIPTION
Tried my hand at writing up a builder in Node.js. :)

I feel like I abstracted some stuff, and eventually ran with it too much, but it works.
Not too sure if I'm keen on the command being available globally, but it's pretty convenient.