### PR TITLE
Copy hex values to clipboard on GitHub pages

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,6 +7,11 @@ body {
 body, .scheme, .author, pre, .block {
   font-family: "menlo", consolas, monospace;
 }
+
+select {
+  font-family: inherit;
+}
+
 .container {
   max-width: 56em;
   margin: 0 auto;

--- a/css/styles.css
+++ b/css/styles.css
@@ -77,3 +77,4 @@ a {
   background: transparent;
   color: transparent;
 }
+

--- a/css/styles.css
+++ b/css/styles.css
@@ -31,6 +31,12 @@ select {
   font-weight: bold;
   padding: 15px;
   margin: 0 5px 10px 0;
+  cursor: pointer;
+  user-select: none;
+}
+.block:active {
+  border: 1px solid white;
+  padding: 14px;
 }
 pre {
   font-size: 14px;
@@ -84,7 +90,6 @@ a {
 }
 
 .copy-btn {
-  /* font-size: 100%; */
   font-family: inherit;
   background: none;
   border: 1px solid #aaa;

--- a/css/styles.css
+++ b/css/styles.css
@@ -98,6 +98,10 @@ a {
   cursor: pointer;
 }
 
+.copy-btns {
+  display: inline-block;
+}
+
 .copy-btn:hover {
   color: #000;
   border-color: #888;

--- a/css/styles.css
+++ b/css/styles.css
@@ -78,3 +78,17 @@ a {
   color: transparent;
 }
 
+.copy-btn {
+  /* font-size: 100%; */
+  font-family: inherit;
+  background: none;
+  border: 1px solid #aaa;
+  border-radius: 2px;
+  color: #333;
+  cursor: pointer;
+}
+
+.copy-btn:hover {
+  color: #000;
+  border-color: #888;
+}

--- a/index.html
+++ b/index.html
@@ -78,10 +78,10 @@
       <option value="base16-unikitty-dark.css">base16-unikitty-dark.css</option>
       <option value="base16-unikitty-light.css">base16-unikitty-light.css</option>
     </select>
-    <button id="copy-css">Copy CSS</button>
-    <button id="copy-formatted-css">Copy Formatted CSS</button>
-    <button id="copy-json">Copy as JSON</button>
-    <button id="copy-txt">Copy as text</button>
+    <button class="copy-btn" id="copy-css">Copy CSS</button>
+    <button class="copy-btn" id="copy-formatted-css">Copy Formatted CSS</button>
+    <button class="copy-btn" id="copy-json">Copy as JSON</button>
+    <button class="copy-btn" id="copy-txt">Copy as text</button>
     <h1 class="scheme"></h1>
     <div>
       <div class="block base00-background base07">00</div>

--- a/index.html
+++ b/index.html
@@ -80,8 +80,8 @@
     </select>
     <button id="copy-css">Copy CSS</button>
     <button id="copy-formatted-css">Copy Formatted CSS</button>
-    <button id="copy-json">Copy JSON</button>
-    <button id="copy-txt">Copy text</button>
+    <button id="copy-json">Copy as JSON</button>
+    <button id="copy-txt">Copy as text</button>
     <h1 class="scheme"></h1>
     <div>
       <div class="block base00-background base07">00</div>

--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
     <button class="copy-btn" id="copy-txt">Copy as text</button>
     <h1 class="scheme"></h1>
     <div>
+      <p style="color: #888; font-size: 75%; font-style: italic;">Click on a color to copy its hex value.</p>
       <div class="block base00-background base07">00</div>
       <div class="block base01-background base07">01</div>
       <div class="block base02-background base07">02</div>

--- a/index.html
+++ b/index.html
@@ -78,10 +78,12 @@
       <option value="base16-unikitty-dark.css">base16-unikitty-dark.css</option>
       <option value="base16-unikitty-light.css">base16-unikitty-light.css</option>
     </select>
-    <button class="copy-btn" id="copy-css">Copy CSS</button>
-    <button class="copy-btn" id="copy-formatted-css">Copy Formatted CSS</button>
-    <button class="copy-btn" id="copy-json">Copy as JSON</button>
-    <button class="copy-btn" id="copy-txt">Copy as text</button>
+    <p class="copy-btns">
+      <button class="copy-btn" id="copy-css">Copy CSS</button>
+      <button class="copy-btn" id="copy-formatted-css">Copy Formatted CSS</button>
+      <button class="copy-btn" id="copy-json">Copy as JSON</button>
+      <button class="copy-btn" id="copy-txt">Copy as text</button>
+    </p>
     <h1 class="scheme"></h1>
     <div>
       <p style="color: #888; font-size: 75%; font-style: italic;">Click on a color to copy its hex value.</p>

--- a/index.html
+++ b/index.html
@@ -78,6 +78,10 @@
       <option value="base16-unikitty-dark.css">base16-unikitty-dark.css</option>
       <option value="base16-unikitty-light.css">base16-unikitty-light.css</option>
     </select>
+    <button id="copy-css">Copy CSS</button>
+    <button id="copy-formatted-css">Copy Formatted CSS</button>
+    <button id="copy-json">Copy JSON</button>
+    <button id="copy-txt">Copy text</button>
     <h1 class="scheme"></h1>
     <div>
       <div class="block base00-background base07">00</div>
@@ -99,6 +103,7 @@
       <div class="block base0F-background base07">0F</div>
     </div>
     <div>
+    
       <pre class="base00-background base05">
 <span class="base0E">require</span> <span class="base0B">"gem"</span>
 

--- a/js/switch.js
+++ b/js/switch.js
@@ -69,9 +69,20 @@
         copy(css)
     })
 
-    document.getElementById('copy-formatted-css').addEventListener('click', function () {
-        
+    document.getElementById('copy-json').addEventListener('click', function () {
+        copy(JSON.stringify(getCSSAsObj(css), null, 2))
     })
+
+    document.getElementById('copy-txt').addEventListener('click', function () {
+        var text = '';
+        var obj = getCSSAsObj(css)
+        var keys = Object.keys(obj)
+        for (var i = 0; i < keys.length; i++) {
+            text += keys[i] + ' ' + obj[keys[i]] + '\n'
+        }
+        copy(text)
+    })
+
 
 
 

--- a/js/switch.js
+++ b/js/switch.js
@@ -2,24 +2,77 @@
 
     var selector = document.getElementById('themeSelector');
     var defaultTheme = selector.value;
-    var themeLink = document.createElement('link');
+    var themeStyleTag = document.createElement('style');
     var indicator = document.querySelector('.scheme');
 
-    themeLink.type = 'text/css';
-    themeLink.rel = 'stylesheet';
+    themeStyleTag.type = 'text/css';
+    themeStyleTag.rel = 'stylesheet';
+
+    var css;
 
     function switchTheme(theme) {
         indicator.innerHTML = 'Preview: ' + theme.substr(0, theme.length - 4);
-        themeLink.disabled = true;
-        themeLink.href = './css/' + theme;
-        themeLink.disabled = false;
+        // themeLink.disabled = true;
+        // themeLink.href = './css/' + theme;
+        // themeLink.disabled = false;
+
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', './css/' + theme)
+        xhr.setRequestHeader("Content-Type", "text/css");
+        xhr.send(null)
+        xhr.addEventListener('readystatechange', function() {
+            if (xhr.readyState === 4 && xhr.status === 200) {
+                css = xhr.responseText
+                themeStyleTag.innerHTML = css
+            }
+        }, false);
     }
 
     switchTheme(defaultTheme);
 
-    document.getElementsByTagName('head')[0].appendChild(themeLink);
+    document.getElementsByTagName('head')[0].appendChild(themeStyleTag);
 
     selector.onchange = function(evt) {
         switchTheme(evt.currentTarget.value);
     };
+
+    function copy(text) {
+        var textarea = document.createElement('textarea')
+        textarea.innerHTML = text
+        textarea.style.width = '0px'
+        textarea.style.height = '0px'
+        textarea.style.padding = '0'
+        textarea.style.position = 'absolute'
+        textarea.style.left = '-100%'
+        document.body.appendChild(textarea)
+        textarea.select()
+        document.execCommand('copy')
+        textarea.parentNode.removeChild(textarea)
+    }
+
+    function getCSSAsObj(css) {
+        var obj = {}
+        var lines = css.split('\n'),
+            splittedLine;
+        for (var i = 0; i < lines.length; i++) {
+            if (lines[i].indexOf(' { color: ') !== -1) {
+                splittedLine = lines[i].split(':')
+                splittedLine[0] = splittedLine[0].substr(1, 6)
+                splittedLine[1] = splittedLine[1].substr(1, 7)
+                obj[splittedLine[0]] = splittedLine[1]
+            }
+        }
+        return obj
+    }
+
+    document.getElementById('copy-css').addEventListener('click', function () {
+        copy(css)
+    })
+
+    document.getElementById('copy-formatted-css').addEventListener('click', function () {
+        
+    })
+
+
+
 })();

--- a/js/switch.js
+++ b/js/switch.js
@@ -65,6 +65,13 @@
         return cssObj
     }
 
+    document.body.addEventListener('click', function (e) {
+        if (!e.target.classList.contains('block')) {
+            return
+        }
+        copy(getCSSAsObj(css)['base' + e.target.textContent])
+    })
+
     document.getElementById('copy-css').addEventListener('click', function () {
         copy(css)
     })

--- a/js/switch.js
+++ b/js/switch.js
@@ -51,7 +51,7 @@
     }
 
     function getCSSAsObj(css) {
-        var obj = {}
+        var cssObj = {}
         var lines = css.split('\n'),
             splittedLine;
         for (var i = 0; i < lines.length; i++) {
@@ -59,14 +59,22 @@
                 splittedLine = lines[i].split(':')
                 splittedLine[0] = splittedLine[0].substr(1, 6)
                 splittedLine[1] = splittedLine[1].substr(1, 7)
-                obj[splittedLine[0]] = splittedLine[1]
+                cssObj[splittedLine[0]] = splittedLine[1]
             }
         }
-        return obj
+        return cssObj
     }
 
     document.getElementById('copy-css').addEventListener('click', function () {
         copy(css)
+    })
+
+    document.getElementById('copy-formatted-css').addEventListener('click', function () {
+        var text = '', cssObj = getCSSAsObj(css), keys = Object.keys(cssObj)
+        for (var i = 0; i < keys.length; i++) {
+            text += '.' + keys[i] + ' { color: ' + cssObj[keys[i]] + '; }\n'
+        }
+        copy(text)
     })
 
     document.getElementById('copy-json').addEventListener('click', function () {
@@ -75,10 +83,10 @@
 
     document.getElementById('copy-txt').addEventListener('click', function () {
         var text = '';
-        var obj = getCSSAsObj(css)
-        var keys = Object.keys(obj)
+        var cssObj = getCSSAsObj(css)
+        var keys = Object.keys(cssObj)
         for (var i = 0; i < keys.length; i++) {
-            text += keys[i] + ' ' + obj[keys[i]] + '\n'
+            text += keys[i] + ' ' + cssObj[keys[i]] + '\n'
         }
         copy(text)
     })


### PR DESCRIPTION
Hi!

Love these color schemes, but as @dkniffin said in #93, it's always a pain to get the hex values.

So, I've basically added 2 little features:

1. You can copy a hex value by clicking on its block (above the preview).
2. You can copy the CSS (the stylesheet basically), a formatted version of it (without the background), a JSON version (`"baseX": "#hex"`), and a text version (`baseX #hex`)

From a user perspective, only this has changed:

![image](https://user-images.githubusercontent.com/15224242/27723709-b4a2f4a2-5db1-11e7-8894-02f017d557ec.png)
