### PR TITLE
list maintained base16-xcode template repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To add your own template, submit a pull request to https://github.com/chriskemps
 * [Vim](https://github.com/chriskempson/base16-vim) maintained by [chriskempson](https://github.com/chriskempson)
 * [VSCode](https://github.com/golf1052/base16-vscode) maintained by [golf1052](https://github.com/golf1052)
 * [Windows Command Prompt](https://github.com/iamthad/base16-windows-command-prompt) maintained by [iamthad](https://github.com/iamthad)
+* [Xcode](https://github.com/kreeger/base16-xcode) maintained by [kreeger]
 * [XFCE4 Terminal](https://github.com/afg984/base16-xfce4-terminal) maintained by [afg984](https://github.com/afg984)
 * [Xresources](https://github.com/chriskempson/base16-xresources) maintained by [chriskempson](https://github.com/chriskempson)
 


### PR DESCRIPTION
Add https://github.com/kreeger/base16-xcode to the list of templates in the README, as it is listed in https://github.com/chriskempson/base16-templates-source/blob/master/list.yaml#L41