### PR TITLE
Add solarflare scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ To add your own scheme, submit a pull request to https://github.com/chriskempson
 * [Onedark](https://github.com/tilal6991/base16-onedark-scheme) maintained by [tilal6991](https://github.com/tilal6991)
 * [Porple](https://github.com/AuditeMarlow/base16-porple-scheme) maintained by [AuditeMarlow](https://github.com/AuditeMarlow)
 * [Rebecca](https://github.com/vic/base16-rebecca) maintained by [vic](https://github.com/vic)
+* [Solarflare](https://github.com/mnussbaum/base16-solarflare-scheme) maintained by [mnussbaum](https://github.com/mnussbaum)
 * [Summerfruit](https://github.com/cscorley/base16-summerfruit-scheme) maintained by [cscorley](https://github.com/cscorley)
 * [Tomorrow](https://github.com/chriskempson/base16-tomorrow-scheme) maintained by [chriskempson](https://github.com/chriskempson)
 * [Twilight](https://github.com/hartbit/base16-twilight-scheme) maintained by [hartbit](https://github.com/hartbit)


### PR DESCRIPTION
I've rehosted the unmaintained solarflare at https://github.com/mnussbaum/base16-solarflare-scheme, with the permission of @chuckharmston the original author.

This PR adds it to the scheme list

Accompanies https://github.com/chriskempson/base16-schemes-source/pull/30 and https://github.com/chriskempson/base16-unclaimed-schemes/pull/5