### PR TITLE
Add tool `auto-base16-theme` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The following is a list of useful resources for anyone creating a Base16 scheme 
 
 * [base16-manager](https://github.com/AuditeMarlow/base16-manager) - A command line tool to install base16 templates and set themes globally.
 * [base16-shell-preview](https://github.com/nvllsvm/base16-shell-preview) - A command line tool to preview and set base16-shell themes.
+* [auto-base16-theme](https://github.com/makuto/auto-base16-theme) - A command line tool to create a base16 theme from an input image's color palette.
 
 ## Projects using Base16
 


### PR DESCRIPTION
I've added a tool which generates a pleasant base16 color scheme from an input image based on that image's color palette.