### PR TITLE
chore(readme): add tmux template repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ To add your own template, submit a pull request to https://github.com/chriskemps
 * [Termite](https://github.com/khamer/base16-termite) maintained by [khamer](https://github.com/khamer)
 * [Termux](https://github.com/kdrag0n/base16-termux) maintained by [kdrag0n](https://github.com/kdrag0n)
 * [TextMate & Sublime Text](https://github.com/chriskempson/base16-textmate) maintained by [chriskempson](https://github.com/chriskempson)
+* [Tmux](https://github.com/mattdavis90/base16-tmux) maintained by [mattdavis90](https://github.com/mattdavis90)
 * [Tilix](https://github.com/karlding/base16-tilix) maintained by [karlding](https://github.com/karlding)
 * [Vim](https://github.com/chriskempson/base16-vim) maintained by [chriskempson](https://github.com/chriskempson)
 * [Vis](https://github.com/pshevtsov/base16-vis) maintained by [pshevtsov](https://github.com/pshevtsov)


### PR DESCRIPTION
It's [in the list](https://github.com/chriskempson/base16-templates-source/blob/master/list.yaml#L46) but not shown in readme.