### PR TITLE
Various builder revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ To add your own scheme, submit a pull request to https://github.com/chriskempson
 
 ### 0.9.0 (Jul 6, 2017)
 
+- Add decimal color variables
+
 * [Base 16 Builder Ansible](https://github.com/mnussbaum/base16-builder-ansible) maintained by [mnussbaum](https://github.com/mnussbaum)
 * [Base 16 Builder Clojure](https://github.com/nhurden/base16-builder-clojure) maintained by [nhurden](https://github.com/nhurden)
 * [Base 16 Builder Elixir](https://github.com/obahareth/base16-builder-elixir) maintained by [obahareth](https://github.com/obahareth)
@@ -138,9 +140,14 @@ To add your own scheme, submit a pull request to https://github.com/chriskempson
 
 ### 0.8.1 (Dec 29, 2016)
 
+- Clarify theme filename generation
+- Various clarifications
+
 * [Base 16 Builder Perl](https://github.com/loomer/base16-builder-perl) maintained by [loomer](https://github.com/loomer)
 
 ### 0.8.0 (Aug 27, 2016)
+
+- Drop support for HSL variables
 
 * [Base 16 Builder Node.js](https://github.com/richardneililagan/base16-builder-node) maintained by [richardneililagan](https://github.com/richardneililagan)
 

--- a/builder.md
+++ b/builder.md
@@ -1,5 +1,5 @@
 # Builder Guidelines
-**Version 0.9.0**
+**Version 0.9.1**
 
 A base16 builder is an application that can build syntax highlighting definition files for text editors by using base16 scheme files which contain a collection of colours and base16 template files which contain syntax highlighting rules. A builder uses Git as the mechanism to download and keep up-to-date syntax files and template files.
 
@@ -17,13 +17,14 @@ The first job a just-installed builder has is to populate a list of scheme sourc
 
 When building themes by running `builder` without any arguments, a base16 builder should first clear out any old output then iterate through all the scheme files in `/schemes` and for each scheme should iterate through all the template files in `/templates` producing themes that will be output to the template directories specified in `/templates/template_name/template/config.yaml`. The theme filename should look like `base16-[slug][extension]`. Where the slug is taken from the scheme filename made lowercase with spaces replaced with dashes and extension is taken from `/template/config.yaml`.
 
+The builder should emit an error or warning when theme files would overlap.
+
 ## Template Variables
 A builder should provide the following variables to a template file:
 
 - `scheme-name` - obtained from the scheme file
 - `scheme-author` - obtained from the scheme file
 - `scheme-slug` - obtained from the scheme filename, as described above
-- `base00-hex` to `base0F-hex` - obtained from the scheme file e.g "7cafc2"
 - `base00-hex-r` to `base0F-hex-r` - built from the hex value in the scheme file e.g "7c"
 - `base00-hex-g` to `base0F-hex-g` - built from the hex value in the scheme file e.g "af"
 - `base00-hex-b` to `base0F-hex-b` - built from the hex value in the scheme file e.g "c2"
@@ -33,6 +34,11 @@ A builder should provide the following variables to a template file:
 - `base00-dec-r` to `base0F-dec-r` - converted from the rgb value in the scheme file e.g "0.87..."
 - `base00-dec-g` to `base0F-dec-g` - converted from the rgb value in the scheme file e.g "0.50..."
 - `base00-dec-b` to `base0F-dec-b` - converted from the rgb value in the scheme file e.g "0.21..."
+
+Builders should also provide the following variables for convenience:
+
+- `base00-hex` to `base0F-hex` - obtained from the scheme file e.g "7cafc2"
+- `base00-hex-bgr` to `base0F-hex-bgr` - built from a reversed version of all the hex values e.g "c2af7c"
 
 ## Code Structure
 There is no outline for a recommended code structure that a base16 theme builder should follow but a design goal should be to keep the application as simple as possible providing only the functionality described in this document. If you feel you have a great idea for additional functionality please raise an issue in the [base16 repository](https://github.com/chriskempson/base16).


### PR DESCRIPTION
This adds baseXX-hex-bgr and adds a recommendation to warn on conflicting files. I'd propose this would be listed as either 0.9.1 or 0.10.0 (as there are new variables - either would be fine with semver because it's not a backwards breaking change), but I'm not sure if there are any other ideas we want to get in.