### PR TITLE
Allow hash in color schemes yaml files

### DIFF
--- a/file.md
+++ b/file.md
@@ -4,11 +4,11 @@ Base16 specifies the format of two types of files: scheme files, used for defini
 ## Template Config Files
 Template files reside in a templates `templates` folder and have the name `config.yaml`. These files have the following example structure:
 
-    default: 
+    default:
         extension: .file-extension
         output: output-directory-name
-        
-    additional: 
+
+    additional:
         extension: .file-extension
         output: output-directory-name
 
@@ -36,4 +36,4 @@ Scheme files have the following example structure:
     base0E: "eeeeee"
     base0F: "ffffff"
 
-Hexadecimal color values should not be preceded by a "#".
+Hexadecimal color values may optionally be preceded by a "#".


### PR DESCRIPTION
The current phrasing says "should not" which isn't very clear and also doesn't explicitly disallow it. I'd like to propose that the hash can optionally be included. There are a number of different editor plugins which can highlight colors, but they usually require that they're preceded by a `#` so it corresponds with an html color code.