### PR TITLE
base16-builder-ansible implements spec version 0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ To add your own scheme, submit a pull request to https://github.com/chriskempson
 - Make baseXX-hex-bgr variables available to templates
 - Warn when a template file has been overwritten
 
+* [Base 16 Builder Ansible](https://github.com/mnussbaum/base16-builder-ansible) maintained by [mnussbaum](https://github.com/mnussbaum)
 * [Base 16 Builder Go](https://github.com/belak/base16-builder-go) maintained by [belak](https://github.com/belak)
 * [Base 16 Builder PHP](https://github.com/chriskempson/base16-builder-php) maintained by [chriskempson](https://github.com/chriskempson)
 * [Base 16 Builder Python](https://github.com/InspectorMustache/base16-builder-python) maintained by [InspectorMustache](https://github.com/InspectorMustache)
@@ -159,7 +160,6 @@ To add your own scheme, submit a pull request to https://github.com/chriskempson
 
 - Add decimal color variables
 
-* [Base 16 Builder Ansible](https://github.com/mnussbaum/base16-builder-ansible) maintained by [mnussbaum](https://github.com/mnussbaum)
 * [Base 16 Builder Clojure](https://github.com/nhurden/base16-builder-clojure) maintained by [nhurden](https://github.com/nhurden)
 * [Base 16 Builder Elixir](https://github.com/obahareth/base16-builder-elixir) maintained by [obahareth](https://github.com/obahareth)
 * [Base 16 Builder Ruby](https://github.com/obahareth/base16-builder-ruby) maintained by [obahareth](https://github.com/obahareth)


### PR DESCRIPTION
Support for spec version 0.9.1 was implemented in [a recent commit](https://github.com/mnussbaum/base16-builder-ansible/commit/f63161458533d5dc1a75529fb4e1fb04bc6885e6)