### PR TITLE
add windows theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ To add your own scheme, submit a pull request to https://github.com/chriskempson
 * [Twilight](https://github.com/hartbit/base16-twilight-scheme) maintained by [hartbit](https://github.com/hartbit)
 * [Unikitty](https://github.com/joshwlewis/base16-unikitty) maintained by [joshwlewis](https://github.com/joshwlewis)
 * [Vice](https://github.com/Thomashighbaugh/base16-vice-scheme) maintained by [Thomashighbaugh](https://github.com/Thomashighbaugh)
+* [Windows](https://github.com/C-Fergus/base16-windows-scheme) maintained by [C-Fergus](https://github.com/C-Fergus)
 * [Woodland](https://github.com/jcornwall/base16-woodland-scheme) maintained by [jcornwall](https://github.com/jcornwall)
 * [Zenburn](https://github.com/elnawe/base16-zenburn-scheme) maintained by [elnawe](https://github.com/elnawe)
 * [XCode Dust](https://github.com/gonsie/base16-xcode-dusk-scheme) maintained by [gonsie](https://github.com/gonsie)


### PR DESCRIPTION
Themes from the Windows terminal palettes from Windows 95 to 10
https://github.com/C-Fergus/base16-windows-scheme