### PR TITLE
Spec 0.10.0 proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,18 @@ To add your own scheme, submit a pull request to https://github.com/chriskempson
 
 **Repository naming scheme: base16-builder-[language]** (with dashes as separators). The separate headings are the latest versions of the spec supported by each builder.
 
+### 0.10.0 (Mar 20, 2021)
+
+- Simplify repo structure and builder responsibilities
+
+* [Base 16 Builder Go](https://github.com/belak/base16-builder-go) maintained by [belak](https://github.com/belak)
+
 ### 0.9.1 (Jun 15, 2019)
 
 - Make baseXX-hex-bgr variables available to templates
 - Warn when a template file has been overwritten
 
 * [Base 16 Builder Ansible](https://github.com/mnussbaum/base16-builder-ansible) maintained by [mnussbaum](https://github.com/mnussbaum)
-* [Base 16 Builder Go](https://github.com/belak/base16-builder-go) maintained by [belak](https://github.com/belak)
 * [Base 16 Builder PHP](https://github.com/chriskempson/base16-builder-php) maintained by [chriskempson](https://github.com/chriskempson)
 * [Base 16 Builder Python](https://github.com/InspectorMustache/base16-builder-python) maintained by [InspectorMustache](https://github.com/InspectorMustache)
 * [Base 16 Builder Rust](https://github.com/ilpianista/base16-builder-rust) maintained by [ilpianista](https://github.com/ilpianista)

--- a/builder.md
+++ b/builder.md
@@ -1,23 +1,31 @@
 # Builder Guidelines
-**Version 0.9.1**
+**Version 0.10.0**
 
-A base16 builder is an application that can build syntax highlighting definition files for text editors by using base16 scheme files which contain a collection of colours and base16 template files which contain syntax highlighting rules. A builder uses Git as the mechanism to download and keep up-to-date syntax files and template files.
+A base16 builder is an application that can build syntax highlighting definition files for text editors by using base16 scheme files which contain a collection of colours and base16 template files which contain syntax highlighting rules.
+
+Builders are designed for theme maintainers' ease of use. Theme maintainers should provide built versions of their theme so the end user doesn't need to be aware of the builder.
 
 ## File Structure
-- `/` - Contains anything you consider appropriate for your builder
-- `/sources.yaml` - Holds a list of source repositories for schemes and templates
-- `/sources/schemes/list.yaml` - Holds a list of scheme repositories
-- `/sources/templates/list.yaml` - Holds a list of template repositories
-- `/schemes/[name]/*.yaml` - A scheme file (there may be multiples of these)
-- `/templates/[name]/templates/*.mustache` - A template file (there may be multiples of these)
-- `/templates/[name]/templates/config.yaml` - A template configuration file
+
+### Schemes Repository
+
+The schemes repo should either be stored in a common location (perhaps referred to by environment variable or command line flag) or dynamically embedded in the builder.
+
+- `/*.yaml`
+
+### Template Repository
+
+Each template repository should have a templates folder containing a config.yaml and any needed mustache template files.
+
+- `/templates/*.mustache` - A template file (there may be multiples of these)
+- `/templates/config.yaml` - A template configuration file
 
 ## Workflow
-The first job a just-installed builder has is to populate a list of scheme sources and template sources. It does this by parsing the `/sources.yaml` file and using Git to clone the repositories defined within to `/sources`. Next, the builder will parse the downloaded `/sources/schemes/list.yaml` and use Git to clone the defined repositories to `/schemes`. Finally, the builder will parse the downloaded `/sources/templates/list.yaml` and use Git to clone the defined repositories to `/templates`. This task is performed by the `builder update` command, which can be used to update sources, schemes, and templates.
+The first thing a builder needs to do is parse all the scheme files from the schemes repository (as defined in the [file guidelines](https://github.com/chriskempson/base16/blob/master/file.md)). All files matching the pattern `*.yaml` should be loaded from the root of the schemes repository.
 
-When building themes by running `builder` without any arguments, a base16 builder should first clear out any old output then iterate through all the scheme files in `/schemes` and for each scheme should iterate through all the template files in `/templates` producing themes that will be output to the template directories specified in `/templates/template_name/template/config.yaml`. The theme filename should look like `base16-[slug][extension]`. Where the slug is taken from the scheme filename made lowercase with spaces replaced with dashes and extension is taken from `/template/config.yaml`.
+When building a target template repository, a base16 builder should first clear out any old output. Next, for all templates defined in the template repo's config file (located at `/templates/config.yaml`), the builder should iterate through all the defined schemes and output matching files. The built filename should look like `[output-dir]/base16-[slug][extension]`, where the slug is taken from the scheme filename made lowercase with spaces replaced with dashes and both the extension and output-dir are taken from `/template/config.yaml`.
 
-In the case where schemes share the same name, a builder will overwrite a perviously generated template file. Should this happen, a builder should show warning messages listing the overwritten template files.
+In the case where schemes share the same slug, a builder will overwrite files perviously generated from the template. Should this happen, a builder should show warning messages listing the overwritten files.
 
 ## Template Variables
 A builder should provide the following variables to a template file:
@@ -45,3 +53,5 @@ There is no outline for a recommended code structure that a base16 theme builder
 
 ## Considerations
 Mustache was chosen as the templating language due to its simplicity and widespread adoption across languages. YAML was chosen to describe scheme and configuration files for the same reasons.
+
+The core scheme repository was based off the single scheme repository so builders supporting v0.8-v0.9 of the spec can continue to function without changes.

--- a/file.md
+++ b/file.md
@@ -4,11 +4,11 @@ Base16 specifies the format of two types of files: scheme files, used for defini
 ## Template Config Files
 Template files reside in a templates `templates` folder and have the name `config.yaml`. These files have the following example structure:
 
-    default: 
+    default:
         extension: .file-extension
         output: output-directory-name
-        
-    additional: 
+
+    additional:
         extension: .file-extension
         output: output-directory-name
 
@@ -36,4 +36,4 @@ Scheme files have the following example structure:
     base0E: "eeeeee"
     base0F: "ffffff"
 
-Hexadecimal color values should not be preceded by a "#".
+Hexadecimal color values may optionally be preceded by a "#".


### PR DESCRIPTION
There is an implementation of this spec proposal at https://github.com/belak/base16-builder-go/pull/16 and a temporary repo containing all the currently defined schemes at https://github.com/belak/base16-schemes.

Eventually, both of those can be transferred to whatever org we end up going with.

The general idea behind this spec change is simplification of the repo structure and builder responsibilities. It would designate a new repo, base16-schemes, containing all the known schemes. This should probably be community maintained. It would also deprecate the base16-schemes-source and base16-templates-source repos.

Right now, a builder is responsible for both git operations and building. The git operations portion is particularly important in the 0.9 spec because there are many repositories to deal with. This proposal would move all schemes back into a single repository (which builders would be expected to either export as a submodule or have cloned in a specific location) and remove the need for the base16 builder to manage a tree of git repositories. Templates would stay in separate repositories and the recommendation would be for builders to be used by the template maintainers to publish built versions of their templates rather than for the end user.

The phrasing was thrown together, so if anyone has recommendations or clarifications I'd be happy to hear them.

# Potential Alternate Versions

- It may be better to use sub-directories in the schemes repo, but for the simplest transition, I decided against it, so the new setup could still be compatible with 0.8-0.9 builders. I'm open to changing this decision if there's a strong reason to (there are something like 177 scheme files, so it does make the repo root file listing very long).

# Refs

- Fixes #52 
- Fixes #256 
- Fixes #257
- Supersedes #258  