### PR TITLE
Add Primer to Scheme Repositories list

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ To add your own scheme, submit a pull request to https://github.com/chriskempson
 * [Pasque](https://github.com/Misterio77/base16-pasque-scheme) maintained by [Misterio77](https://github.com/Misterio77)
 * [pinky](https://github.com/b3nj5m1n/base16-pinky-scheme) maintained by [b3nj5m1n](https://github.com/b3nj5m1n)
 * [Porple](https://github.com/AuditeMarlow/base16-porple-scheme) maintained by [AuditeMarlow](https://github.com/AuditeMarlow)
+* [Primer](https://github.com/jmlntw/base16-primer-scheme) maintained by [jmlntw](https://github.com/jmlntw)
 * [Purpledream](https://github.com/archmalet/base16-purpledream-scheme) maintained by [archmalet](https://github.com/archmalet)
 * [Qualia](https://github.com/isaacwhanson/base16-qualia-scheme) maintained by [isaacwhanson](https://github.com/isaacwhanson)
 * [Rebecca](https://github.com/vic/base16-rebecca) maintained by [vic](https://github.com/vic)


### PR DESCRIPTION
Add [jmlntw/base16-primer-scheme](https://github.com/jmlntw/base16-primer-scheme) to Scheme Repositories list.
