### PR TITLE
Add base16-pandora-scheme to schemes list

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ To add your own scheme, submit a pull request to https://github.com/chriskempson
 * [One Light](https://github.com/purpleKarrot/base16-one-light-scheme) maintained by [purpleKarrot](https://github.com/purpleKarrot)
 * [Onedark](https://github.com/tilal6991/base16-onedark-scheme) maintained by [tilal6991](https://github.com/tilal6991)
 * [Outrun](https://github.com/hugodelahousse/base16-outrun-schemes) maintained by [hugodelahousse](https://github.com/hugodelahousse)
+* [Pandora](https://github.com/pandorasfox/base16-pandora-scheme) maintained by [pandorasfox](https://github.com/pandorasfox)
 * [PaperColor](https://github.com/jonleopard/base16-papercolor-scheme) maintained by [jonleopard](https://github.com/jonleopard)
 * [Pasque](https://github.com/Misterio77/base16-pasque-scheme) maintained by [Misterio77](https://github.com/Misterio77)
 * [pinky](https://github.com/b3nj5m1n/base16-pinky-scheme) maintained by [b3nj5m1n](https://github.com/b3nj5m1n)


### PR DESCRIPTION
This pull should only be merged after https://github.com/chriskempson/base16-schemes-source/pull/90 is merged and actually added to the schemes list