### PR TITLE
add link for base16-showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Base16 was designed with the following limitations to ensure the project remains
 * [flavours](https://github.com/misterio77/flavours) - A command line tool to manage and globally apply base16 templates by specifying a scheme name.
 * [Themix/Oomox](https://github.com/themix-project/oomox) - Graphical application for generating different colour variations of a Arc, Materia and Oomox themes (GTK2, GTK3 and others), Archdroid, Gnome-Colours and Numix icons, and terminal palette. Base16 plugin allows to open Base16 YAML files a export both Base16 and its own themes using Base16 Mustache templates.
 * [base16-spectrum-generator](https://github.com/alexmirrington/base16-spectrum-generator) - A Python script for generating `.png` files showcasing the colours in a base16 theme.
+* [base16-showcase](https://github.com/lucasew/base16-showcase) - A simple [website](https://base16-showcase.vercel.app/) that shows the colors of many base16 palletes at once.
 
 ## Used By
 * [Visual Studio Code](https://code.visualstudio.com) - Tommorrow Night Blue theme included by default.


### PR DESCRIPTION
I did a simple tool once before to help me choose which base16 I would use in my system. Right now I am using classic-dark.

I think it would be useful for people wanting to adopt the colorscheme as it is to me.